### PR TITLE
fix: resolve auth state loss on app resume

### DIFF
--- a/components/AppNavbar.tsx
+++ b/components/AppNavbar.tsx
@@ -77,37 +77,55 @@ export default function AppNavbar() {
     initializeAuth();
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange(async (event, newSession) => {
-      setSession(newSession);
-      sessionRef.current = newSession;
+      try {
+        setSession(newSession);
+        sessionRef.current = newSession;
 
-      if (event === 'SIGNED_OUT') {
-        await resetToGuestState();
-        window.location.href = '/';
-        return;
-      }
-      
-      if (newSession) {
-        setIsSyncPending(hasPendingPrediction(newSession.user.id));
-        triggerSync(newSession);
-
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('username, is_admin')
-          .eq('id', newSession.user.id)
-          .single();
-        
-        if (profile) {
-          setCurrentUser(profile.username);
-          setIsAdmin(!!profile.is_admin);
-          await storage.setItem('p10_cache_username', profile.username);
-          await storage.setItem('p10_cache_is_admin', String(!!profile.is_admin));
-        } else {
-          const fallback = newSession.user.email?.split('@')[0] || 'User';
-          setCurrentUser(fallback);
-          await storage.setItem('p10_cache_username', fallback);
+        if (event === 'SIGNED_OUT') {
+          await resetToGuestState();
+          window.location.href = '/';
+          return;
         }
-      } else if (event !== 'INITIAL_SESSION') {
-        await resetToGuestState();
+        
+        if (newSession) {
+          setIsSyncPending(hasPendingPrediction(newSession.user.id));
+          triggerSync(newSession);
+
+          // Get profile with timeout to prevent hanging on resume
+          const profilePromise = supabase
+            .from('profiles')
+            .select('username, is_admin')
+            .eq('id', newSession.user.id)
+            .maybeSingle();
+          
+          const timeoutPromise = new Promise((_, reject) => setTimeout(() => reject(new Error('Profile fetch timeout')), 5000));
+          
+          try {
+            const result = await Promise.race([profilePromise, timeoutPromise]) as { data: { username: string, is_admin: boolean } | null };
+            const { data: profile } = result;
+            
+            if (profile) {
+              setCurrentUser(profile.username);
+              setIsAdmin(!!profile.is_admin);
+              await storage.setItem('p10_cache_username', profile.username);
+              await storage.setItem('p10_cache_is_admin', String(!!profile.is_admin));
+            } else {
+              const fallback = newSession.user.email?.split('@')[0] || 'User';
+              setCurrentUser(fallback);
+              await storage.setItem('p10_cache_username', fallback);
+            }
+          } catch (profileErr) {
+             console.warn('Auth state profile fetch failed:', profileErr);
+             // Fallback to email if profile fetch fails (e.g. offline)
+             const fallback = newSession.user.email?.split('@')[0] || 'User';
+             setCurrentUser(fallback);
+          }
+        } else if (event !== 'INITIAL_SESSION' && event !== 'TOKEN_REFRESHED') {
+          // Selective reset: only if it's not a background refresh event
+          await resetToGuestState();
+        }
+      } catch (err) {
+        console.error('onAuthStateChange error:', err);
       }
     });
 
@@ -119,8 +137,21 @@ export default function AppNavbar() {
 
     let appStateListener: Promise<PluginListenerHandle> | undefined;
     if (Capacitor.isNativePlatform()) {
-      appStateListener = App.addListener('appStateChange', ({ isActive }) => {
-        if (isActive && sessionRef.current) triggerSync(sessionRef.current);
+      appStateListener = App.addListener('appStateChange', async ({ isActive }) => {
+        if (isActive) {
+          console.log('App resumed, re-verifying session...');
+          try {
+            // Force a session refresh check when app is resumed
+            const { data: { session: resumedSession } } = await supabase.auth.getSession();
+            if (resumedSession) {
+              setSession(resumedSession);
+              sessionRef.current = resumedSession;
+              triggerSync(resumedSession);
+            }
+          } catch (err) {
+            console.error('Session re-verify error:', err);
+          }
+        }
       });
     }
 

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,13 +1,12 @@
-import { createBrowserClient } from '@supabase/ssr'
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 import { storage } from '../storage'
 
-// Custom storage adapter for Supabase to use our universal storage
+/**
+ * Custom storage adapter for Supabase to use our universal storage utility.
+ * This ensures the session is mirrored to Native Preferences on Android/iOS.
+ */
 const supabaseStorage = {
   getItem: (key: string) => {
-    // Supabase expect a string or null synchronously for its internal state
-    // but can handle async storage if provided. However, our getItem is async.
-    // We use a trick: we return the promise, and Supabase handles it if it's an async storage.
     return storage.getItem(key);
   },
   setItem: (key: string, value: string) => {
@@ -24,29 +23,33 @@ const getSupabaseEnv = () => {
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   
   if (!url || !anonKey) {
-    console.error('CRITICAL: Supabase environment variables are missing!', {
-      url: !!url,
-      anonKey: !!anonKey
-    });
+    console.error('CRITICAL: Supabase environment variables are missing!');
   }
   
   return { url: url || '', anonKey: anonKey || '' };
 };
 
-// Browser-safe client for Next.js components
+/**
+ * Browser-safe client for Next.js components.
+ * Configured with persistent storage for Capacitor.
+ */
 export function createClient() {
   const { url, anonKey } = getSupabaseEnv();
-  return createBrowserClient(url, anonKey, {
+  return createSupabaseClient(url, anonKey, {
     auth: {
       storage: supabaseStorage,
       autoRefreshToken: true,
       persistSession: true,
-      detectSessionInUrl: true
+      detectSessionInUrl: true,
+      flowType: 'pkce'
     }
   });
 }
 
-// Standard client for Node.js scripts / tests
+/**
+ * Standard client for Node.js scripts / tests.
+ * Uses the same storage to maintain consistency in local environments.
+ */
 export function createServerClient() {
   const { url, anonKey } = getSupabaseEnv();
   return createSupabaseClient(url, anonKey, {
@@ -54,7 +57,8 @@ export function createServerClient() {
       storage: supabaseStorage,
       autoRefreshToken: true,
       persistSession: true,
-      detectSessionInUrl: true
+      detectSessionInUrl: true,
+      flowType: 'pkce'
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p10-racing",
-  "version": "1.20.6",
+  "version": "1.20.7",
   "private": false,
   "license": "UNLICENSED",
   "scripts": {


### PR DESCRIPTION
- Switch Supabase client to standard createClient for better Capacitor compatibility.
- Add appStateChange listener to re-verify session when app is resumed.
- Implement timeouts and fallbacks for profile fetching in auth state changes.
- Ensure session persistence is robustly mirrored to Native Preferences.
- Increment version to 1.20.7.