### PR TITLE
chore: sync package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "p10-racing",
-  "version": "1.11.17",
+  "version": "1.18.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p10-racing",
-      "version": "1.11.17",
+      "version": "1.18.10",
+      "license": "UNLICENSED",
       "dependencies": {
         "@capacitor/android": "^8.0.2",
         "@capacitor/app": "^8.0.1",


### PR DESCRIPTION
Synchronizing package-lock.json with package.json version 1.18.10. This ensures reproducibility and consistency in the CI/CD pipeline.