### PR TITLE
feat: enhance bug diagnostics and storage visibility

### DIFF
--- a/components/BugReportModal.tsx
+++ b/components/BugReportModal.tsx
@@ -7,6 +7,7 @@ import { triggerMediumHaptic, triggerSuccessHaptic, triggerErrorHaptic } from '@
 import { Capacitor } from '@capacitor/core';
 import { Device } from '@capacitor/device';
 import { Network } from '@capacitor/network';
+import { STORAGE_KEYS } from '@/lib/utils/storage';
 import packageInfo from '../package.json';
 import HapticButton from './HapticButton';
 
@@ -34,11 +35,13 @@ export default function BugReportModal({ show, onHide }: BugReportModalProps) {
     if (typeof window === 'undefined') return {};
     try {
       const keys = Object.keys(localStorage);
-      const summary: Record<string, number | boolean> = {
+      const summary: Record<string, any> = {
         total_keys: keys.length,
-        has_session: !!localStorage.getItem('supabase.auth.token') || !!localStorage.getItem('sb-yozhuvzmxpntjrvoxxps-auth-token'),
-        has_predictions: !!localStorage.getItem('p10_predictions'),
-        has_drivers: !!localStorage.getItem('p10_drivers_cache'),
+        all_keys: keys,
+        has_session: !!localStorage.getItem(STORAGE_KEYS.HAS_SESSION),
+        has_predictions: keys.some(k => k.startsWith('final_pred_')),
+        has_drivers: !!localStorage.getItem(STORAGE_KEYS.CACHE_DRIVERS),
+        has_grid: keys.some(k => k.startsWith('p10_cache_grid_')),
       };
       return summary;
     } catch {

--- a/components/NativeWrapper.tsx
+++ b/components/NativeWrapper.tsx
@@ -43,7 +43,8 @@ export default function NativeWrapper({ children }: { children: React.ReactNode 
     };
 
     console.error = (...args: unknown[]) => {
-      const message = args.map(arg => safeStringify(arg)).join(' ');
+      const timestamp = new Date().toLocaleTimeString();
+      const message = `[${timestamp}] ` + args.map(arg => safeStringify(arg)).join(' ');
       window.__P10_ERROR_LOGS__ = [message, ...window.__P10_ERROR_LOGS__].slice(0, 10);
       originalError.apply(console, args);
     };

--- a/lib/supabase/sync_github_issues.ts
+++ b/lib/supabase/sync_github_issues.ts
@@ -63,6 +63,7 @@ ${bug.description}
 - **Session:** ${storage.has_session ? '✅ Active' : '❌ None'}
 - **Predictions:** ${storage.has_predictions ? '✅ Cached' : '❌ None'}
 - **Drivers:** ${storage.has_drivers ? '✅ Cached' : '❌ None'}
+${storage.all_keys ? `- **All Keys:** \`${storage.all_keys.join(', ')}\`` : ''}
 
 ${Array.isArray(deviceInfo.recent_errors) && deviceInfo.recent_errors.length > 0 ? `
 ### Recent Console Errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p10-racing",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p10-racing",
-      "version": "1.26.1",
+      "version": "1.26.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@capacitor/android": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p10-racing",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "private": false,
   "license": "UNLICENSED",
   "scripts": {


### PR DESCRIPTION
This PR finalizes the bug reporting diagnostic improvements:
- **Storage Keys:** Fixed a bug where storage keys (session, predictions, drivers) were not detected due to a string mismatch.
- **Full Key Visibility:** Now captures and displays the full list of `localStorage` keys in the GitHub issue for better sync debugging.
- **Console Timestamps:** Added localized timestamps to the intercepted console error logs (`__P10_ERROR_LOGS__`).
- **Versioning:** Bumps to 1.26.2.