### PR TITLE
fix: increase default shake threshold to 800

### DIFF
--- a/components/NativeWrapper.tsx
+++ b/components/NativeWrapper.tsx
@@ -63,7 +63,7 @@ export default function NativeWrapper({ children }: { children: React.ReactNode 
     let lastUpdate = 0;
     let lastX = 0, lastY = 0, lastZ = 0;
     // Sensitivity threshold for shake detection (lower is more sensitive)
-    const SHAKE_THRESHOLD = Number(process.env.NEXT_PUBLIC_SHAKE_THRESHOLD) || 200;
+    const SHAKE_THRESHOLD = Number(process.env.NEXT_PUBLIC_SHAKE_THRESHOLD) || 800;
     const COOLDOWN = 2000; // 2 seconds between triggers
     let lastShakeTime = 0;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p10-racing",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p10-racing",
-      "version": "1.27.4",
+      "version": "1.27.5",
       "license": "UNLICENSED",
       "dependencies": {
         "@capacitor/android": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p10-racing",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "private": false,
   "license": "UNLICENSED",
   "scripts": {


### PR DESCRIPTION
Increase default shake threshold from 200 to 800 as 500 was reported to be too sensitive.