### PR TITLE
ci: allow manual workflow_dispatch for android release

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -60,7 +60,7 @@ jobs:
   release-android:
     name: Android Release Build
     needs: validate
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable')
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This PR updates the 'release-android' job condition to allow manual triggers via 'workflow_dispatch', ensuring we can recover if a push event is missed.