### PR TITLE
feat: tag-only stable releases with manual promotion

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -164,29 +164,20 @@ jobs:
           mkdir -p distribution/whatsnew
           touch distribution/whatsnew/whatsnew-en-GB
           
-          if [[ "${{ github.ref }}" == "refs/heads/stable" ]]; then
-            # Attempt to get PR description for stable releases
-            git log -1 --pretty=format:"%s" | grep -oE "#[0-9]+" | head -1 | tr -d '#' > pr_number.txt || true
-            read -r PR_NUMBER < pr_number.txt || true
-            if [ -n "$PR_NUMBER" ]; then
-              gh pr view "$PR_NUMBER" --json body --template '{{.body}}' | head -c 500 > distribution/whatsnew/whatsnew-en-GB || true
-            fi
+          # We only generate notes for internal (main) track automatically.
+          # Stable releases use manual promotion.
+          if [[ "${{ steps.set_env.outputs.TAG_SUFFIX }}" == "-internal" ]]; then
+            git describe --tags --match "v*-internal" --abbrev=0 2>/dev/null > last_tag.txt || true
+          else
+            # Fallback for non-internal tracks if ever enabled
+            git describe --tags --match "v*" --exclude "*-internal" --abbrev=0 2>/dev/null > last_tag.txt || true
           fi
           
-          # Fallback if stable PR not found or on main
-          if [ ! -s distribution/whatsnew/whatsnew-en-GB ]; then
-            if [[ "${{ steps.set_env.outputs.TAG_SUFFIX }}" == "-internal" ]]; then
-              git describe --tags --match "v*-internal" --abbrev=0 2>/dev/null > last_tag.txt || true
-            else
-              git describe --tags --match "v*" --exclude "*-internal" --abbrev=0 2>/dev/null > last_tag.txt || true
-            fi
-            
-            read -r LAST_TAG < last_tag.txt || true
-            if [ -z "$LAST_TAG" ]; then
-              git log -5 --pretty=format:"- %s" | head -c 500 > distribution/whatsnew/whatsnew-en-GB || true
-            else
-              git log "$LAST_TAG"..HEAD --pretty=format:"- %s" | head -c 500 > distribution/whatsnew/whatsnew-en-GB || true
-            fi
+          read -r LAST_TAG < last_tag.txt || true
+          if [ -z "$LAST_TAG" ]; then
+            git log -5 --pretty=format:"- %s" | head -c 500 > distribution/whatsnew/whatsnew-en-GB || true
+          else
+            git log "$LAST_TAG"..HEAD --pretty=format:"- %s" | head -c 500 > distribution/whatsnew/whatsnew-en-GB || true
           fi
           
           if [ ! -s distribution/whatsnew/whatsnew-en-GB ]; then

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -28,7 +28,6 @@ We use a dual-track release process with **Branch Protection** enforced on `main
 *   **Branch:** `stable`
 *   **Workflow:** Pull Request from `main`.
 *   **Android:** GitHub Actions automatically tags the release as `vX.X.X`. The build is **NOT** uploaded; instead, the maintainer manually promotes the successful Internal Testing build to the Closed Testing track in the Google Play Console.
-*   **Tagging:** Automatically tagged as `vX.X.X`.
 
 ---
 


### PR DESCRIPTION
This PR refactors the release pipeline to prevent duplicate builds and automate version tracking via tags.

### Key Changes
- **Main Branch:** Continues to build and upload to the **Internal Testing** track automatically.
- **Stable Branch:** Now performs **Git Tagging only**. It will no longer trigger a fresh Android build or upload.
- **Workflow Cleanup:** Removed unreachable stable-specific logic from the 'Generate Release Notes' step.
- **Mandate Refinement:** Streamlined 'GEMINI.md' to remove redundancy in the release section.

### How to Release (Maintainer Action)
1. Merge `main` -> `stable`.
2. The pipeline will automatically create the `vX.X.X` tag.
3. Go to **Google Play Console** -> **Internal Testing**.
4. Select the successful build and click **Promote Release** -> **Closed Testing**.