### PR TITLE
fix(ui): unify swipeable tab pill positioning

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -658,7 +658,7 @@ h1, h2, h3, h4, h5, h6, p, span, div, label {
 
 /* Pull to Refresh Spacing Balance */
 .ptr-content-wrapper {
-  padding-top: 0.75rem; /* Gap between header and content when pulling */
+  padding-top: 0; /* Align with pages that don't have pull-to-refresh */
 }
 
 /* Ensure no double margin when sticky is active */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p10-racing",
-  "version": "1.39.3",
+  "version": "1.39.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p10-racing",
-      "version": "1.39.3",
+      "version": "1.39.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@capacitor/android": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p10-racing",
-  "version": "1.39.3",
+  "version": "1.39.4",
   "private": false,
   "license": "UNLICENSED",
   "scripts": {


### PR DESCRIPTION
## What's New
Aligned the 'swipeable pill' positioning in  by removing an inconsistent  from the  wrapper. This ensures the tab bar maintains a consistent distance from the header across all pages, whether they have pull-to-refresh enabled or not.

### Changes:
- ****: Set  for .
- ****: Bumped version to `1.39.4`.