### PR TITLE
fix(edge): allow X-Cron-Secret in CORS and add logging

### DIFF
--- a/lib/supabase/edge_function_check.ts
+++ b/lib/supabase/edge_function_check.ts
@@ -22,7 +22,7 @@ Deno.serve(async (req) => {
   // 1. CORS Headers
   const corsHeaders = {
     'Access-Control-Allow-Origin': '*', // System task, but good practice
-    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-cron-secret',
   };
 
   if (req.method === 'OPTIONS') {
@@ -33,6 +33,8 @@ Deno.serve(async (req) => {
   const authHeader = req.headers.get('Authorization');
   const customCronHeader = req.headers.get('X-Cron-Secret');
   const CRON_SECRET = Deno.env.get('CRON_SECRET');
+
+  console.log('Request received. Auth Header present:', !!authHeader, 'Custom Header present:', !!customCronHeader);
   
   if (CRON_SECRET) {
     const expectedBearer = `Bearer ${CRON_SECRET}`;
@@ -42,7 +44,7 @@ Deno.serve(async (req) => {
       customCronHeader === CRON_SECRET;
 
     if (!isAuthorized) {
-      console.warn('Unauthorized trigger attempt rejected');
+      console.warn('Unauthorized trigger attempt rejected. Secrets do not match.');
       return new Response('Unauthorized', { status: 401, headers: corsHeaders });
     }
   }


### PR DESCRIPTION
## What's New
- Added `x-cron-secret` to the allowed CORS headers to prevent browser/gateway blocks during manual testing.
- Added logging to track header presence for easier 401 debugging.