### PR TITLE
refactor: address final reviewer feedback for PR #134

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -181,6 +181,11 @@ export default function HistoryPage() {
     return tabId === 'history' ? renderHistory() : renderAchievements();
   };
 
+  const tabs = [
+    { id: 'history', label: 'History', icon: <HistoryIcon size={16} /> },
+    { id: 'achievements', label: 'Trophies', icon: <Trophy size={16} /> }
+  ] as const;
+
   return (
     <SwipeablePageLayout
       title="Season Progress"
@@ -188,12 +193,9 @@ export default function HistoryPage() {
       icon={<HistoryIcon size={24} className="text-white" />}
       onBack={() => { triggerLightHaptic(); router.back(); }}
       activeTab={activeTab}
-      onTabChange={(id) => { triggerMediumHaptic(); setActiveTab(id as HistoryTab); }}
+      onTabChange={(id) => { triggerMediumHaptic(); setActiveTab(id); }}
       renderTabContent={renderTabContent}
-      tabs={[
-        { id: 'history', label: 'History', icon: <HistoryIcon size={16} /> },
-        { id: 'achievements', label: 'Trophies', icon: <Trophy size={16} /> }
-      ]}
+      tabs={tabs}
     />
   );
 }

--- a/app/leagues/page.tsx
+++ b/app/leagues/page.tsx
@@ -486,8 +486,8 @@ function LeaguesContent() {
 
   const renderTabContent = (tabId: 'my-leagues' | 'manage') => (
     <div className="mt-3">
-      {/* Show alerts in the primary pane */}
-      {tabId === 'my-leagues' && (
+      {/* Show alerts if it's the active tab (mobile) or always in the first pane (split view) */}
+      {((tabId === activeTab) || (tabId === 'my-leagues')) && (
         <FeedbackAlerts 
           error={error}
           setError={setError}

--- a/components/SwipeablePageLayout.tsx
+++ b/components/SwipeablePageLayout.tsx
@@ -22,7 +22,7 @@ interface SwipeablePageLayoutProps<T extends string> {
   icon: ReactNode;
   activeTab: T;
   onTabChange: (tabId: T) => void;
-  tabs: TabOption<T>[];
+  tabs: readonly TabOption<T>[];
   children?: ReactNode;
   onRefresh?: () => Promise<void>;
   badge?: ReactNode;


### PR DESCRIPTION
Addresses feedback from PR #134:
- **Leagues**: Fixed regression where alerts were hidden on mobile when 'Manage' was active.
- **History**: Improved type safety using `as const` for tabs and removing manual casts.
- **SwipeablePageLayout**: Updated `tabs` prop to be `readonly` to support const assertions.