### PR TITLE
fix(edge): prevent crash in isTrueDnf with null status

### DIFF
--- a/lib/supabase/edge_function_check.ts
+++ b/lib/supabase/edge_function_check.ts
@@ -23,7 +23,7 @@ interface RaceResultItem {
  * Excludes DNS (Did not start) and other non-participation statuses.
  */
 function isTrueDnf(status: string, laps: string | number = "1"): boolean {
-  const s = status.toLowerCase();
+  const s = status?.toLowerCase() || '';
   const isFinished = s === "finished" || s.includes("lap");
   const isDns = s.includes("not start") || s === "dns" || s.includes("qualify") || s.includes("withdrawn");
   const lapCount = typeof laps === 'string' ? parseInt(laps) : laps;

--- a/lib/supabase/f1_live_proxy.ts
+++ b/lib/supabase/f1_live_proxy.ts
@@ -45,7 +45,7 @@ interface SessionInfo {
  * Shared utility to determine if a status string indicates a true DNF.
  */
 function isTrueDnf(status: string, laps: string | number = "1"): boolean {
-  const s = status.toLowerCase();
+  const s = status?.toLowerCase() || '';
   const isFinished = s === "finished" || s.includes("lap");
   const isDns = s.includes("not start") || s === "dns" || s.includes("qualify") || s.includes("withdrawn");
   const lapCount = typeof laps === 'string' ? parseInt(laps) : laps;

--- a/lib/supabase/f1_signalr_relay.ts
+++ b/lib/supabase/f1_signalr_relay.ts
@@ -20,7 +20,7 @@ const HUB_NAME = 'Streaming';
  * other non-participation statuses.
  */
 function isTrueDnf(status: string, laps: string | number = "1"): boolean {
-  const s = status.toLowerCase();
+  const s = status?.toLowerCase() || '';
   const isFinished = s === "finished" || s.includes("lap");
   const isDns = s.includes("not start") || s === "dns" || s.includes("qualify") || s.includes("withdrawn");
   const lapCount = typeof laps === 'string' ? parseInt(laps) : laps;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p10-racing",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p10-racing",
-      "version": "1.41.0",
+      "version": "1.41.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@capacitor/android": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p10-racing",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "private": false,
   "license": "UNLICENSED",
   "scripts": {


### PR DESCRIPTION
## What's New
Critical hotfix for Supabase Edge Functions:
- Added null checks to `status.toLowerCase()` in the `isTrueDnf` utility.
- Prevents 500 errors when F1 telemetry or results contain missing status fields.
- Applied across Proxy, Relay, and Results Checker.