### PR TITLE
feat: allow deletion of guest data in migration prompt

### DIFF
--- a/components/GuestMigrationPrompt.tsx
+++ b/components/GuestMigrationPrompt.tsx
@@ -10,7 +10,7 @@ import { STORAGE_KEYS } from '@/lib/utils/storage';
 
 export default function GuestMigrationPrompt() {
   const { session } = useAuth();
-  const { localGuests, isImporting, importingGuest, error, success, importGuestData } = useGuestMigration();
+  const { localGuests, isImporting, importingGuest, error, success, importGuestData, deleteGuestData } = useGuestMigration();
   const [show, setShow] = useState(false);
   const [internalDismissed, setInternalDismissed] = useState(false);
 
@@ -67,18 +67,31 @@ export default function GuestMigrationPrompt() {
             <div className="d-flex flex-column gap-2 mb-4">
               {localGuests.map(guest => (
                 <div key={guest} className="d-flex align-items-center justify-content-between bg-black bg-opacity-25 p-2 px-3 rounded-3 border border-secondary border-opacity-25">
-                  <span className="fw-bold text-white small">{guest}</span>
-                  <HapticButton 
-                    haptic="medium" 
-                    variant="warning" 
-                    size="sm" 
-                    className="fw-bold py-1 px-3 rounded-pill text-uppercase"
-                    style={{ fontSize: '0.7rem' }}
-                    onClick={() => importGuestData(guest)} 
-                    disabled={isImporting}
-                  >
-                    {importingGuest === guest ? <Spinner animation="border" size="sm" /> : 'Import'}
-                  </HapticButton>
+                  <span className="fw-bold text-white small text-truncate pe-2">{guest}</span>
+                  <div className="d-flex gap-2">
+                    <HapticButton 
+                      haptic="medium" 
+                      variant="outline-danger" 
+                      size="sm" 
+                      className="fw-bold py-1 px-2 rounded-pill text-uppercase border-0 opacity-75 hover-opacity-100"
+                      style={{ fontSize: '0.65rem' }}
+                      onClick={() => deleteGuestData(guest)} 
+                      disabled={isImporting}
+                    >
+                      Delete
+                    </HapticButton>
+                    <HapticButton 
+                      haptic="medium" 
+                      variant="warning" 
+                      size="sm" 
+                      className="fw-bold py-1 px-3 rounded-pill text-uppercase"
+                      style={{ fontSize: '0.7rem' }}
+                      onClick={() => importGuestData(guest)} 
+                      disabled={isImporting}
+                    >
+                      {importingGuest === guest ? <Spinner animation="border" size="sm" /> : 'Import'}
+                    </HapticButton>
+                  </div>
                 </div>
               ))}
             </div>

--- a/lib/hooks/use-guest-migration.ts
+++ b/lib/hooks/use-guest-migration.ts
@@ -165,6 +165,19 @@ export function useGuestMigration() {
     }
   };
 
+  const deleteGuestData = (guestName: string) => {
+    const updatedPlayers = localGuests.filter(p => p !== guestName);
+    localStorage.setItem(STORAGE_KEYS.PLAYERS_LIST, JSON.stringify(updatedPlayers));
+    if (mountedRef.current) setLocalGuests(updatedPlayers);
+    
+    for (let round = 1; round <= 24; round++) {
+      localStorage.removeItem(getPredictionKey(CURRENT_SEASON, guestName, round));
+    }
+    
+    triggerHeavyHaptic();
+    triggerRefresh();
+  };
+
   return {
     localGuests,
     isImporting: !!importingGuest,
@@ -172,6 +185,8 @@ export function useGuestMigration() {
     error,
     success,
     importGuestData,
+    deleteGuestData,
     refreshGuests: loadLocalGuests
   };
 }
+

--- a/lib/hooks/use-guest-migration.ts
+++ b/lib/hooks/use-guest-migration.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { createClient } from '@/lib/supabase/client';
-import { STORAGE_KEYS, getPredictionKey, setStorageItem } from '@/lib/utils/storage';
+import { STORAGE_KEYS, getPredictionKey, setStorageItem, removeStorageItem } from '@/lib/utils/storage';
 import { CURRENT_SEASON } from '@/lib/data';
 import { triggerHeavyHaptic, triggerSuccessHaptic } from '@/lib/utils/haptics';
 import { useAuth } from '@/components/AuthProvider';
@@ -166,12 +166,14 @@ export function useGuestMigration() {
   };
 
   const deleteGuestData = (guestName: string) => {
+    setError(null);
+    setSuccess(null);
     const updatedPlayers = localGuests.filter(p => p !== guestName);
-    localStorage.setItem(STORAGE_KEYS.PLAYERS_LIST, JSON.stringify(updatedPlayers));
+    setStorageItem(STORAGE_KEYS.PLAYERS_LIST, JSON.stringify(updatedPlayers));
     if (mountedRef.current) setLocalGuests(updatedPlayers);
     
     for (let round = 1; round <= 24; round++) {
-      localStorage.removeItem(getPredictionKey(CURRENT_SEASON, guestName, round));
+      removeStorageItem(getPredictionKey(CURRENT_SEASON, guestName, round));
     }
     
     triggerHeavyHaptic();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p10-racing",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p10-racing",
-      "version": "1.48.1",
+      "version": "1.48.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@capacitor/android": "^8.0.2",
@@ -494,7 +494,6 @@
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -505,7 +504,6 @@
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p10-racing",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "private": false,
   "license": "UNLICENSED",
   "scripts": {

--- a/tests/guest_migration.vitest.test.ts
+++ b/tests/guest_migration.vitest.test.ts
@@ -185,4 +185,38 @@ describe('useGuestMigration', () => {
     const guests = JSON.parse(localStorage.getItem(STORAGE_KEYS.PLAYERS_LIST) || '[]');
     expect(guests).toEqual([guestName]);
   });
+
+  it('should successfully delete guest data and cleanup', async () => {
+    const guestName = 'Alice';
+    const guests = [guestName, 'Bob'];
+    
+    localStorage.setItem(STORAGE_KEYS.PLAYERS_LIST, JSON.stringify(guests));
+    
+    // Set some predictions for Alice
+    const pred1 = { p10: 'VER', dnf: 'SAR' };
+    localStorage.setItem(getPredictionKey(CURRENT_SEASON, guestName, 1), JSON.stringify(pred1));
+
+    const triggerRefresh = vi.fn();
+    (useAuth as any).mockReturnValue({ 
+      session: null,
+      triggerRefresh,
+      displayName: 'AuthUser'
+    });
+
+    const { result } = renderHook(() => useGuestMigration());
+
+    act(() => {
+      result.current.deleteGuestData(guestName);
+    });
+
+    // Verify cleanup
+    const updatedGuests = JSON.parse(localStorage.getItem(STORAGE_KEYS.PLAYERS_LIST) || '[]');
+    expect(updatedGuests).toEqual(['Bob']);
+    expect(result.current.localGuests).toEqual(['Bob']);
+    
+    // Verify individual predictions removed from guest
+    expect(localStorage.getItem(getPredictionKey(CURRENT_SEASON, guestName, 1))).toBeNull();
+
+    expect(triggerRefresh).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## What's New
- Added a 'Delete' button to the Guest Migration Prompt so users can permanently discard orphaned or unwanted local accounts.
- Added `deleteGuestData` to the `useGuestMigration` hook which removes the guest from `PLAYERS_LIST` and drops their cached predictions.
- Resolves issue where the local data popup kept appearing every time the app was opened despite having no visible local data.
- Incremented version to 1.48.2.